### PR TITLE
Update to gson 2.11.0 - 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ allprojects {
         testCompile "org.testcontainers:kafka:1.15.0-rc2"
         testCompile "org.testcontainers:mockserver:1.15.0-rc2"
         testCompile "org.mock-server:mockserver-client-java:5.11.1"
-        testCompile "com.google.code.gson:gson:2.8.6"
+        testCompile "com.google.code.gson:gson:2.11.0"
 
         testCompile group: 'org.mockito', name: 'mockito-junit-jupiter', version: '2.26.0'
         compile group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.15.0'

--- a/source/build.gradle
+++ b/source/build.gradle
@@ -1,7 +1,7 @@
 description = "Kafka Connect Source connector that reads from DynamoDB streams"
 
 dependencies {
-    implementation 'com.google.code.gson:gson:2.8.2'
+    implementation 'com.google.code.gson:gson:2.11.0'
     implementation 'com.amazonaws:aws-java-sdk-resourcegroupstaggingapi:1.11.551'
 
     compile group: 'org.apache.kafka', name: 'connect-api', version: "${rootProject.ext.kafkaConnectApiVersion}"

--- a/source/src/test/java/com/trustpilot/connector/dynamodb/StubOffsetStorageReader.java
+++ b/source/src/test/java/com/trustpilot/connector/dynamodb/StubOffsetStorageReader.java
@@ -1,7 +1,7 @@
 package com.trustpilot.connector.dynamodb;
 
 import org.apache.kafka.connect.storage.OffsetStorageReader;
-import sun.reflect.generics.reflectiveObjects.NotImplementedException;
+import java.lang.UnsupportedOperationException;
 
 import java.util.Collection;
 import java.util.Map;
@@ -25,6 +25,6 @@ public class StubOffsetStorageReader implements OffsetStorageReader {
 
     @Override
     public <T> Map<Map<String, T>, Map<String, Object>> offsets(Collection<Map<String, T>> partitions) {
-        throw new NotImplementedException();
+        throw new UnsupportedOperationException();
     }
 }


### PR DESCRIPTION
Update to the latest gson release to fix module issues: `java.lang.reflect.InaccessibleObjectException: Unable to make field final byte[] java.nio.ByteBuffer.hb accessible: module java.base does not "opens java.nio" to unnamed module`.

Hopefully this works and there's no other breaking changes... it builds at least.

Also fix minor warning about `NotImplementedException` in testing code.